### PR TITLE
Property name mapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 /composer.lock
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /vendor/
 /composer.lock
-/.idea/

--- a/src/Normalizer/Exception/MissingPropertyException.php
+++ b/src/Normalizer/Exception/MissingPropertyException.php
@@ -25,6 +25,7 @@
 
 namespace TheSaleGroup\Restorm\Normalizer\Exception;
 
+use Exception;
 use TheSaleGroup\Restorm\Exception\RestormException;
 
 /**
@@ -32,7 +33,6 @@ use TheSaleGroup\Restorm\Exception\RestormException;
  *
  * @author Rob Treacy <robert.treacy@thesalegroup.co.uk>
  */
-class MissingPropertyException implements RestormException
+class MissingPropertyException extends Exception implements RestormException
 {
-    
 }

--- a/src/Normalizer/Exception/UnknownTransformerException.php
+++ b/src/Normalizer/Exception/UnknownTransformerException.php
@@ -25,6 +25,7 @@
 
 namespace TheSaleGroup\Restorm\Normalizer\Exception;
 
+use Exception;
 use TheSaleGroup\Restorm\Exception\RestormException;
 
 /**
@@ -32,7 +33,6 @@ use TheSaleGroup\Restorm\Exception\RestormException;
  *
  * @author Rob Treacy <robert.treacy@thesalegroup.co.uk>
  */
-class UnknownTransformerException implements RestormException
+class UnknownTransformerException extends Exception implements RestormException
 {
-    
 }

--- a/src/Normalizer/Normalizer.php
+++ b/src/Normalizer/Normalizer.php
@@ -67,7 +67,7 @@ class Normalizer
     public function denormalize(\stdClass $data, EntityMetadata $entityMetadata)
     {
         foreach ($entityMetadata->getEntityMapping()->getProperties() as $propertyName => $propertyOptions) {
-            $mapFrom = isset($propertyOptions['map_from']) ? $propertyOptions['map_from'] : $propertyName;
+            $mapFrom = $propertyOptions['map_from'] ?? $propertyName;
 
             if (!property_exists($data, $mapFrom)) {
                 throw new Exception\MissingPropertyException(sprintf('Property "%s" was not available in the response.', $mapFrom));

--- a/src/Normalizer/Normalizer.php
+++ b/src/Normalizer/Normalizer.php
@@ -67,13 +67,14 @@ class Normalizer
     public function denormalize(\stdClass $data, EntityMetadata $entityMetadata)
     {
         foreach ($entityMetadata->getEntityMapping()->getProperties() as $propertyName => $propertyOptions) {
+            $mapFrom = isset($propertyOptions['map_from']) ? $propertyOptions['map_from'] : $propertyName;
 
-            if (!property_exists($data, $propertyName)) {
-                throw new Exception\MissingPropertyException(sprintf('Property "%s" was not available in the response.', $propertyName));
+            if (!property_exists($data, $mapFrom)) {
+                throw new Exception\MissingPropertyException(sprintf('Property "%s" was not available in the response.', $mapFrom));
             }
 
             $propertyType = $propertyOptions['type'];
-            $dataValue = $data->$propertyName;
+            $dataValue = $data->$mapFrom;
 
             $transformer = $this->getTransformer($propertyType);
 

--- a/src/Normalizer/Transformer/BooleanTransformer.php
+++ b/src/Normalizer/Transformer/BooleanTransformer.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TheSaleGroup\Restorm\Normalizer\Transformer;
+
+class BooleanTransformer implements TransformerInterface
+{
+    public function normalize($value)
+    {
+        return (boolean) $value;
+    }
+
+    public function denormalize($value)
+    {
+        return (boolean) $value;
+    }
+}


### PR DESCRIPTION
Fixes #5 

## Proposed Changes

  - Checks for custom `map_from` configuration for each entity property and falls back to using one to one mapping.
  - Fixes custom exceptions with missing `extends \Exception`
  - Adds `boolean` transformer
