### PR TITLE
Always return EntityCollection for non single queries

### DIFF
--- a/src/EntityRepository.php
+++ b/src/EntityRepository.php
@@ -72,13 +72,14 @@ class EntityRepository implements RepositoryInterface
             ->get($this->entityClass)
             ->where([$identifierField => $id])
             ->getQuery()
-            ->getResult();
+            ->getSingleResult();
     }
 
     public function findAll($offset = 0, $limit = null)
     {
         return $this->getQueryBuilder()
             ->get($this->entityClass)
+            ->page($page, $limit)
             ->getQuery()
             ->getResult();
     }


### PR DESCRIPTION
Fixes #34 

## Proposed Changes

  - Add new method for querying for a single result
  - Force an `EntityCollection` to return if multiple results expected, regardless of whether none, one, or many results are returned.
