### PR TITLE
Fixes #43 Return an empty EntityCollection on null multiple entities

### DIFF
--- a/src/Normalizer/Transformer/EntityTransformer.php
+++ b/src/Normalizer/Transformer/EntityTransformer.php
@@ -46,7 +46,7 @@ class EntityTransformer implements AdvancedTransformerInterface
     public function denormalize($value, array $options)
     {
         if ($value === null) {
-            return null;
+            return $options['multiple'] ?? false ? new EntityCollection : null;
         }
 
         $entityClass = $options['entity'];


### PR DESCRIPTION
Fixes #43 

## Proposed Changes

  - Return an empty EntityCollection when `null` is returned as the response data for an "entity" type with "multiple" set as `true`