### PR TITLE
Allow entity inheritance when proxying.

### DIFF
--- a/src/Entity/Proxy.php
+++ b/src/Entity/Proxy.php
@@ -118,6 +118,8 @@ class Proxy implements EventSubscriberInterface
 
     private function getPropertyProxyName(string $entityClass, string $property): string
     {
-        return sprintf("\0%s\0%s", $entityClass, $property);
+        $reflectionProperty = new \ReflectionProperty($entityClass, $property);
+
+        return $reflectionProperty->getDeclaringClass()->getName() === $entityClass ? sprintf("\0%s\0%s", $entityClass, $property) : sprintf("\0*\0%s", $property);
     }
 }


### PR DESCRIPTION
Correctly defines inherited properties in the proxy manager's intialiser to allow lazy loading of entities with inherited properties.
